### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/org/apache/commons/ognl/ASTMethod.java
+++ b/src/main/java/org/apache/commons/ognl/ASTMethod.java
@@ -247,7 +247,7 @@ public class ASTMethod
 
         if ( method.getReturnType() == void.class )
         {
-            coreExpression = sourceStringBuilder.toString() + ";";
+            coreExpression = sourceStringBuilder + ";";
             lastExpression = "null";
         }
 
@@ -409,3 +409,4 @@ public class ASTMethod
         return visitor.visit( this, data );
     }
 }
+

--- a/src/main/java/org/apache/commons/ognl/SimpleNode.java
+++ b/src/main/java/org/apache/commons/ognl/SimpleNode.java
@@ -125,7 +125,7 @@ public abstract class SimpleNode
 
     public String toString( String prefix )
     {
-        return prefix + OgnlParserTreeConstants.jjtNodeName[id] + " " + toString();
+        return prefix + OgnlParserTreeConstants.jjtNodeName[id] + " " + ;
     }
 
     public String toGetSourceString( OgnlContext context, Object target )


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-commons-ognl-UnnecessaryToStringCall-18cd37e496ecbea4868a891dbdbf9cabae907aa0-sl:128-el:0-sc:73-ec:0-co:3205-cl:8 -->
<!-- fingerprint:Qodana-commons-ognl-UnnecessaryToStringCall-18cd37e496ecbea4868a891dbdbf9cabae907aa0-sl:250-el:0-sc:50-ec:0-co:8290-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (2)
